### PR TITLE
mesonpy: add heuristics to try mapping unknown install paths to wheel

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,9 @@ def test(session):
         session.install('pytest-github-actions-annotate-failures')
 
     session.run(
-        'pytest', '--cov', '--cov-config', 'setup.cfg',
+        'pytest',
+        '--showlocals', '-vv',
+        '--cov', '--cov-config', 'setup.cfg',
         f'--cov-report=html:{htmlcov_output}',
         f'--cov-report=xml:{xmlcov_output}',
         'tests/', *session.posargs

--- a/tests/packages/configure-data/configure_data.py.in
+++ b/tests/packages/configure-data/configure_data.py.in
@@ -1,0 +1,2 @@
+def message():
+    return 'meson says: @MSG@'

--- a/tests/packages/configure-data/meson.build
+++ b/tests/packages/configure-data/meson.build
@@ -1,0 +1,16 @@
+project(
+    'configure-data',
+    version: '1.0.0',
+)
+
+py_mod = import('python')
+py = py_mod.find_installation()
+
+configure_file(
+    input: 'configure_data.py.in',
+    output: 'configure_data.py',
+    configuration: configuration_data({
+        'MSG': 'hello!',
+    }),
+    install_dir: py.get_install_dir(),
+)

--- a/tests/packages/configure-data/pyproject.toml
+++ b/tests/packages/configure-data/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'mesonpy'
+requires = ['mesonpy']

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -47,3 +47,14 @@ def test_pure(wheel_pure):
         'pure-1.0.0.dist-info/WHEEL',
         'pure.py',
     }
+
+
+def test_configure_data(wheel_configure_data):
+    artifact = wheel.wheelfile.WheelFile(wheel_configure_data)
+
+    assert set(artifact.namelist()) == {
+        'configure_data-1.0.0.data/platlib/configure_data.py',
+        'configure_data-1.0.0.dist-info/METADATA',
+        'configure_data-1.0.0.dist-info/RECORD',
+        'configure_data-1.0.0.dist-info/WHEEL',
+    }


### PR DESCRIPTION
This will map files that do not use {py_purelib}/{py_platlib}
placeholders, which is the case of targets that receive the install
location as a string in the Meson build files (eg. configure_file).

Signed-off-by: Filipe Laíns <lains@riseup.net>