### PR TITLE
tests: fix wheel content tests

### DIFF
--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -9,10 +9,18 @@ import wheel.wheelfile
 EXT_SUFFIX = sysconfig.get_config_var('EXT_SUFFIX')
 
 
+def wheel_contents(artifact):
+    # Sometimes directories have entries, sometimes not, so we filter them out.
+    return {
+        entry for entry in artifact.namelist()
+        if not entry.endswith('/')
+    }
+
+
 def test_contents(package_library, wheel_library):
     artifact = wheel.wheelfile.WheelFile(wheel_library)
 
-    for name, regex in zip(sorted(artifact.namelist()), [
+    for name, regex in zip(sorted(wheel_contents(artifact)), [
         re.escape('library-1.0.0.data/scripts/example'),
         re.escape('library-1.0.0.dist-info/METADATA'),
         re.escape('library-1.0.0.dist-info/RECORD'),
@@ -25,7 +33,7 @@ def test_contents(package_library, wheel_library):
 def test_purelib_and_platlib(wheel_purelib_and_platlib):
     artifact = wheel.wheelfile.WheelFile(wheel_purelib_and_platlib)
 
-    assert set(artifact.namelist()) == {
+    assert wheel_contents(artifact) == {
         f'plat{EXT_SUFFIX}',
         'purelib_and_platlib-1.0.0.data/purelib/pure.py',
         'purelib_and_platlib-1.0.0.dist-info/METADATA',
@@ -37,7 +45,7 @@ def test_purelib_and_platlib(wheel_purelib_and_platlib):
 def test_pure(wheel_pure):
     artifact = wheel.wheelfile.WheelFile(wheel_pure)
 
-    assert set(artifact.namelist()) == {
+    assert wheel_contents(artifact) == {
         'pure-1.0.0.dist-info/METADATA',
         'pure-1.0.0.dist-info/RECORD',
         'pure-1.0.0.dist-info/WHEEL',
@@ -48,7 +56,7 @@ def test_pure(wheel_pure):
 def test_configure_data(wheel_configure_data):
     artifact = wheel.wheelfile.WheelFile(wheel_configure_data)
 
-    assert set(artifact.namelist()) == {
+    assert wheel_contents(artifact) == {
         'configure_data-1.0.0.data/platlib/configure_data.py',
         'configure_data-1.0.0.dist-info/METADATA',
         'configure_data-1.0.0.dist-info/RECORD',


### PR DESCRIPTION
This has been very flaky, as it depends on how external dependencies,
like auditwheel, handle things, so let's just filter directory entries
out from the wheel content tests.

Signed-off-by: Filipe Laíns <lains@riseup.net>