### PR TITLE
mesonpy: fix getting the version from Meson

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -411,6 +411,13 @@ class Project():
         # configure the meson project; reconfigure if the user provided a build directory
         self._configure(reconfigure=bool(build_dir) and not native_file_mismatch)
 
+        # set version if dynamic (this fetches it from Meson)
+        if self._metadata and 'version' in self._metadata.dynamic:
+            self._metadata.version = self.version
+            # version is no longer dynamic
+            # XXX: Should this be automatically handled by pep621/pyproject-metadata?
+            self._metadata.dynamic.remove('version')
+
     def _proc(self, *args: str) -> None:
         print('{cyan}{bold}+ {}{reset}'.format(' '.join(args), **_STYLES))
         subprocess.check_call(list(args))

--- a/tests/packages/dynamic-version/meson.build
+++ b/tests/packages/dynamic-version/meson.build
@@ -1,0 +1,4 @@
+project(
+    'dynamic-version',
+    version: '1.0.0',
+)

--- a/tests/packages/dynamic-version/pyproject.toml
+++ b/tests/packages/dynamic-version/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+build-backend = 'mesonpy'
+requires = ['mesonpy']
+
+[project]
+name = 'dynamic-version'
+dynamic = [
+    'version',
+]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -46,3 +46,13 @@ def test_pep621(sdist_full_metadata):
 
         An example package with all of the PEP 621 metadata!
     ''')
+
+
+def test_dynamic_version(sdist_dynamic_version):
+    sdist = tarfile.open(sdist_dynamic_version, 'r:gz')
+
+    assert sdist.extractfile('dynamic_version-1.0.0/PKG-INFO').read().decode().strip() == textwrap.dedent('''
+        Metadata-Version: 2.1
+        Name: dynamic-version
+        Version: 1.0.0
+    ''').strip()


### PR DESCRIPTION
I think this broke with pep621 changes.

Signed-off-by: Filipe Laíns <lains@riseup.net>