### PR TITLE
mesonpy: the patchelf dependency is Posix only

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -774,7 +774,7 @@ def get_requires_for_build_wheel(
 ) -> List[str]:
     dependencies = [_depstr.wheel, _depstr.ninja]
     with _project(config_settings) as project:
-        if not project.is_pure:
+        if not project.is_pure and os.name == 'posix':
             dependencies.append(_depstr.patchelf_wrapper)
         if project.pep621:
             dependencies.append(_depstr.pep621)

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -1,10 +1,18 @@
 # SPDX-License-Identifier: EUPL-1.2
 
+import os
+
 import pytest
 
 import mesonpy
 
 from .conftest import cd_package
+
+
+if os.name == 'posix':
+    VENDORING_DEPS = {mesonpy._depstr.patchelf_wrapper}
+else:
+    VENDORING_DEPS = set()
 
 
 @pytest.mark.parametrize(
@@ -24,8 +32,8 @@ def test_get_requires_for_build_sdist(package, expected):
     [
         ('pure', set()),  # pure and no PEP 621
         ('full-metadata', {mesonpy._depstr.pep621}),  # pure and PEP 621
-        ('library', {mesonpy._depstr.patchelf_wrapper}),  # not pure and not PEP 621
-        ('library-pep621', {mesonpy._depstr.patchelf_wrapper, mesonpy._depstr.pep621}),  # not pure and PEP 621
+        ('library', VENDORING_DEPS),  # not pure and not PEP 621
+        ('library-pep621', {mesonpy._depstr.pep621, *VENDORING_DEPS}),  # not pure and PEP 621
     ]
 )
 def test_get_requires_for_build_wheel(package, expected):


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>