### PR TITLE
mesonpy: fix Cygwin compability

### DIFF
--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -1,0 +1,47 @@
+name: tests-cygwin
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - '3.10'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up target Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Setup Cygwin
+        uses: cygwin/cygwin-install-action@v2
+
+      - name: Install nox
+        run: |
+            python -m pip install nox
+            nox --version
+
+      - name: Run tests
+        run: nox -s test-${{ matrix.python }}
+
+      - name: Send coverage report
+        uses: codecov/codecov-action@v1
+        env:
+          PYTHON: cygwin-${{ matrix.python }}
+        with:
+          flags: tests
+          env_vars: PYTHON
+          name: cygwin-${{ matrix.python }}

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import os
 import pathlib
+import platform
 import re
 import shutil
 import subprocess
@@ -277,7 +278,7 @@ class _WheelBuilder():
         counter.update(location)
 
         # fix file
-        if os.name == 'posix':
+        if platform.system() == 'Linux':
             # add .mesonpy.libs to the RPATH of ELF files
             if self._is_elf(os.fspath(origin)):
                 # copy ELF to our working directory to avoid Meson having to regenerate the file
@@ -322,7 +323,7 @@ class _WheelBuilder():
 
                 # install bundled libraries
                 for destination, origin in wheel_files['mesonpy-libs']:
-                    assert os.name == 'posix', 'Bundling libraries in wheel is currently only supported in POSIX!'
+                    assert platform.system() == 'Linux', 'Bundling libraries in wheel is currently only supported in POSIX!'
                     destination = pathlib.Path(f'.{self._project.name}.mesonpy.libs', destination)
                     self._install_file(whl, counter, origin, destination)
 
@@ -774,7 +775,7 @@ def get_requires_for_build_wheel(
 ) -> List[str]:
     dependencies = [_depstr.wheel, _depstr.ninja]
     with _project(config_settings) as project:
-        if not project.is_pure and os.name == 'posix':
+        if not project.is_pure and platform.system() == 'Linux':
             dependencies.append(_depstr.patchelf_wrapper)
         if project.pep621:
             dependencies.append(_depstr.pep621)

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 
-import os
+import platform
 
 import pytest
 
@@ -9,7 +9,7 @@ import mesonpy
 from .conftest import cd_package
 
 
-if os.name == 'posix':
+if platform.system() == 'Linux':
     VENDORING_DEPS = {mesonpy._depstr.patchelf_wrapper}
 else:
     VENDORING_DEPS = set()

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
 
-import os
 import platform
 import re
 import subprocess
@@ -53,7 +52,7 @@ def wheel_contents(artifact):
     }
 
 
-@pytest.mark.skipif(os.name != 'posix', reason='Needs library vendoring, only implemented in POSIX')
+@pytest.mark.skipif(platform.system() != 'Linux', reason='Needs library vendoring, only implemented in POSIX')
 def test_contents(package_library, wheel_library):
     artifact = wheel.wheelfile.WheelFile(wheel_library)
 


### PR DESCRIPTION
On Cygwin os.name returns "posix", so we need to check for "Linux" in
platform.system() instead.

Signed-off-by: Filipe Laíns <lains@riseup.net>